### PR TITLE
Avoid warnings about `type-punned`

### DIFF
--- a/src/SensorFusion.cpp
+++ b/src/SensorFusion.cpp
@@ -57,12 +57,13 @@ SF::SF()
 float SF::invSqrt(float x)
 {
 	float halfx = 0.5f * x;
-	float y = x;
-	long i = *(long*)&y;
-	i = 0x5f3759df - (i>>1);
-	y = *(float*)&i;
-	y = y * (1.5f - (halfx * y * y));
-	y = y * (1.5f - (halfx * y * y));
+	union {
+	  float    f;
+	  uint32_t i;
+	} conv = { .f = x };
+	conv.i = 0x5f3759df - (conv.i >> 1);
+	conv.f *= 1.5f - (halfx * conv.f * conv.f);
+	conv.f *= 1.5f - (halfx * conv.f * conv.f);
 	return y;
 }
 


### PR DESCRIPTION
Hello,

  you used for estimating `inverse square root` old solution and modern compiler gives me warning:
```python
/Users/martin/Documents/Arduino/libraries/SensorFusion/src/SensorFusion.cpp: In static member function 'static float SF::invSqrt(float)':
/Users/martin/Documents/Arduino/libraries/SensorFusion/src/SensorFusion.cpp:61:20: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  long i = *(long*)&y;
                    ^
/Users/martin/Documents/Arduino/libraries/SensorFusion/src/SensorFusion.cpp:63:16: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  y = *(float*)&i;
                ^
```

The better way is using `union` as a trick. Thanks.
